### PR TITLE
Use timestamp(3) to match precision of Joda-Time

### DIFF
--- a/txbits/app/views/exchange/account.scala.html
+++ b/txbits/app/views/exchange/account.scala.html
@@ -55,16 +55,17 @@
                                 <tr><td>@Messages("exchange.account.api_reference.sell")</td><td class="money">/api/1/ask</td></tr>
                                 <tr><td></td><td class="json-ref">{"api_key":"","base":"","counter":"","amount":"","price":""}</td></tr>
                                 <tr><td>@Messages("exchange.account.api_reference.cancel_order")</td><td class="money">/api/1/cancel</td></tr>
-                                <tr><td></td><td class="json-ref">{"api_key":"","order":""}</td></tr>
+                                <tr><td></td><td class="json-ref">{"api_key":"","order":}</td></tr>
                                 <tr><td>@Messages("exchange.account.api_reference.list_orders")</td><td class="money">/api/1/pending_trades</td></tr>
                                 <tr><td></td><td class="json-ref">{"api_key":""}</td></tr>
                                 <tr><td>@Messages("exchange.account.api_reference.trade_history")</td><td class="money">/api/1/trade_history</td></tr>
-                                <tr><td></td><td class="json-ref">{"api_key":""<i>,"before":"","limit":"","last_id":""</i>}</td></tr>
+                                <tr><td></td><td class="json-ref">{"api_key":""<i>,"before":,"limit":,"last_id":</i>}</td></tr>
                                 <tr><td>@Messages("exchange.account.api_reference.list_balance")</td><td class="money">/api/1/balance</td></tr>
                                 <tr><td></td><td class="json-ref">{"api_key":""}</td></tr>
                             </tbody>
                         </table>
-                        <p>@Messages("exchange.account.api_reference.example"): curl -H "Content-Type: application/json" -X POST -d '{"api_key":""}' https://example.com/api/1/balance</p>
+                        <p>@Messages("exchange.account.api_reference.type_info")</p>
+                        <p>@Messages("exchange.account.api_reference.example"): curl -H "Content-Type: application/json" -X POST -d '{"api_key":"<b>API_KEY</b>","order":<b>42</b>}' https://example.com/api/1/cancel</p>
                     </div>
                 </div>
             </div>

--- a/txbits/conf/evolutions/default/1.sql
+++ b/txbits/conf/evolutions/default/1.sql
@@ -46,7 +46,7 @@ create table trade_fees (
 
 create table users (
     id bigint primary key,
-    created timestamp default current_timestamp not null,
+    created timestamp(3) default current_timestamp not null,
     email varchar(256) not null,
     on_mailing_list bool default false not null,
     tfa_enabled bool default false not null,
@@ -59,7 +59,7 @@ create unique index unique_lower_email on users (lower(email));
 create table users_passwords (
     user_id bigint not null,
     password varchar(256) not null, -- salt is a part of the password field
-    created timestamp default current_timestamp not null,
+    created timestamp(3) default current_timestamp not null,
     foreign key (user_id) references users(id),
     primary key (user_id, created)
 );
@@ -68,7 +68,7 @@ create table users_api_keys (
     user_id bigint not null,
     api_key text not null unique check(length(api_key) = 24), -- 18 bytes in Base64
     comment text not null default '',
-    created timestamp default current_timestamp not null,
+    created timestamp(3) default current_timestamp not null,
     active bool default true not null,
     trading bool default false not null,
     trade_history bool default false not null,
@@ -80,7 +80,7 @@ create table users_api_keys (
 create table users_tfa_secrets (
     user_id bigint not null,
     tfa_secret varchar(256),
-    created timestamp default current_timestamp not null,
+    created timestamp(3) default current_timestamp not null,
     foreign key (user_id) references users(id),
     primary key (user_id, created)
 );
@@ -88,7 +88,7 @@ create table users_tfa_secrets (
 create table users_backup_otps (
     user_id bigint not null,
     otp int not null,
-    created timestamp default current_timestamp not null,
+    created timestamp(3) default current_timestamp not null,
     foreign key (user_id) references users(id),
     primary key (user_id, otp)
 );
@@ -102,7 +102,7 @@ create table trusted_action_requests (
 create table totp_tokens_blacklist (
     user_id bigint not null,
     token int not null,
-    expiration timestamp not null,
+    expiration timestamp(3) not null,
     foreign key (user_id) references users(id)
 );
 create index totp_tokens_blacklist_expiration_idx on totp_tokens_blacklist(expiration desc);
@@ -110,7 +110,7 @@ create index totp_tokens_blacklist_expiration_idx on totp_tokens_blacklist(expir
 create sequence event_log_id_seq;
 create table event_log (
     id bigint default nextval('event_log_id_seq') primary key,
-    created timestamp default current_timestamp not null,
+    created timestamp(3) default current_timestamp not null,
     email varchar(256),
     user_id bigint,
     ip inet,
@@ -161,7 +161,7 @@ create table markets (
 create sequence order_id_seq;
 create table orders (
     id bigint default nextval('order_id_seq') primary key,
-    created timestamp default current_timestamp not null,
+    created timestamp(3) default current_timestamp not null,
     original numeric(23,8) not null check(original > 0),
     closed bool default false not null,
     remains numeric(23,8) not null check(original >= remains and (remains > 0 or remains = 0 and closed = true)),
@@ -188,7 +188,7 @@ create table matches (
     ask_fee numeric(23,8) not null check(ask_fee >= 0),
     bid_fee numeric(23,8) not null check(bid_fee >= 0),
     price numeric(23,8) not null check(price > 0),
-    created timestamp default current_timestamp not null,
+    created timestamp(3) default current_timestamp not null,
     is_bid bool not null, -- true when an ask was matched by a new bid
     base varchar(4) not null,
     counter varchar(4) not null,
@@ -233,8 +233,8 @@ create table users_addresses (
     user_id bigint default 0 not null,
     currency varchar(4) not null,
     node_id integer not null,
-    created timestamp default current_timestamp not null,
-    assigned timestamp,
+    created timestamp(3) default current_timestamp not null,
+    assigned timestamp(3),
     foreign key (currency) references currencies(currency),
     foreign key (currency, node_id) references wallets_crypto(currency, node_id),
     foreign key (user_id) references users(id)
@@ -245,7 +245,7 @@ create sequence deposit_withdraw_id_seq;
 create table deposits (
     id bigint default nextval('deposit_withdraw_id_seq') primary key,
     amount numeric(23,8) not null check(amount > 0), -- before the fee
-    created timestamp default current_timestamp not null,
+    created timestamp(3) default current_timestamp not null,
     user_id bigint not null,
     currency varchar(4) not null,
     fee numeric(23,8) not null check(fee >= 0),
@@ -260,7 +260,7 @@ create table deposits_crypto (
     amount numeric(23,8) not null, -- already in deposits but needed here for a unique constraint
     tx_hash varchar(64) not null,
     address varchar(34) not null,
-    confirmed timestamp,
+    confirmed timestamp(3),
     unique(address, tx_hash, amount),
     foreign key (id, amount) references deposits(id, amount),
     foreign key (address) references users_addresses(address),
@@ -276,12 +276,12 @@ create table deposits_other (
 create table withdrawals (
     id bigint default nextval('deposit_withdraw_id_seq') primary key,
     amount numeric(23,8) not null check(amount > 0), -- before the fee
-    created timestamp default current_timestamp not null,
+    created timestamp(3) default current_timestamp not null,
     user_id bigint not null,
     currency varchar(4) not null,
     fee numeric(23,8) not null check(fee >= 0),
     confirmation_token varchar(256) default null, -- this is set to non-null when the user trust service sends out the token
-    token_expiration timestamp, -- this is set to non-null when the user trust service sends out the token
+    token_expiration timestamp(3), -- this is set to non-null when the user trust service sends out the token
     user_confirmed boolean not null default false,
     user_rejected boolean not null default false,
     check(not (user_confirmed and user_rejected)),
@@ -300,9 +300,9 @@ create table withdrawals_crypto_tx (
     tx_amount numeric(23,8) check(tx_amount >= 0),
     tx_fee numeric(23,8) check(tx_fee >= 0),
     node_id integer not null,
-    created timestamp default current_timestamp not null,
-    sent timestamp,
-    confirmed timestamp,
+    created timestamp(3) default current_timestamp not null,
+    sent timestamp(3),
+    confirmed timestamp(3),
     check((tx_hash is null and sent is null) or (tx_hash is not null and sent is not null)),
     check(sent is not null or confirmed is null),
     foreign key (currency) references currencies(currency),
@@ -340,8 +340,8 @@ create table withdrawals_other (
 create table tokens (
     token varchar(256) not null primary key,
     email varchar(256) not null,
-    creation timestamp not null,
-    expiration timestamp not null,
+    creation timestamp(3) not null,
+    expiration timestamp(3) not null,
     is_signup bool not null
 );
 create index tokens_expiration_idx on tokens(expiration desc);
@@ -350,7 +350,7 @@ create index tokens_expiration_idx on tokens(expiration desc);
 create table stats_30_min (
     base varchar(4) not null,
     counter varchar(4) not null,
-    start_of_period timestamp not null check(extract(minute from start_of_period) in (0, 30)),
+    start_of_period timestamp(3) not null check(extract(minute from start_of_period) in (0, 30)),
     volume numeric(23,8) not null,
     low numeric(23,8) not null,
     high numeric(23,8) not null,

--- a/txbits/conf/evolutions/default/1.sql
+++ b/txbits/conf/evolutions/default/1.sql
@@ -229,7 +229,7 @@ create table wallets_crypto (
 create sequence address_id_seq;
 create table users_addresses (
     id bigint default nextval('address_id_seq') primary key,
-    address varchar(34) not null unique,
+    address varchar(35) not null unique,
     user_id bigint default 0 not null,
     currency varchar(4) not null,
     node_id integer not null,
@@ -259,7 +259,7 @@ create table deposits_crypto (
     id bigint not null primary key,
     amount numeric(23,8) not null, -- already in deposits but needed here for a unique constraint
     tx_hash varchar(64) not null,
-    address varchar(34) not null,
+    address varchar(35) not null,
     confirmed timestamp(3),
     unique(address, tx_hash, amount),
     foreign key (id, amount) references deposits(id, amount),
@@ -311,7 +311,7 @@ create table withdrawals_crypto_tx (
 
 create table withdrawals_crypto_tx_cold_storage (
     id bigint not null primary key,
-    address varchar(34) not null,
+    address varchar(35) not null,
     value numeric(23,8) not null check(value > 0),
     foreign key (id) references withdrawals_crypto_tx(id)
 );
@@ -325,7 +325,7 @@ create table withdrawals_crypto_tx_mutated (
 create table withdrawals_crypto (
     id bigint not null primary key,
     withdrawals_crypto_tx_id bigint,
-    address varchar(34) not null,
+    address varchar(35) not null,
     foreign key (id) references withdrawals(id) on delete cascade,
     foreign key (withdrawals_crypto_tx_id) references withdrawals_crypto_tx(id)
 );

--- a/txbits/conf/evolutions/default/2.sql
+++ b/txbits/conf/evolutions/default/2.sql
@@ -1415,7 +1415,7 @@ create or replace function
 get_addresses (
   a_uid bigint,
   a_currency varchar(4),
-  out o_address varchar(34),
+  out o_address varchar(35),
   out o_assigned timestamp(3)
 ) returns setof record as $$
 declare
@@ -1459,7 +1459,7 @@ create or replace function
 get_all_addresses (
   a_uid bigint,
   out o_currency varchar(4),
-  out o_address varchar(34),
+  out o_address varchar(35),
   out o_assigned timestamp(3)
 ) returns setof record as $$
 begin
@@ -1506,7 +1506,7 @@ user_pending_withdrawals (
   out amount numeric(23,8),
   out fee numeric(23,8),
   out created timestamp(3),
-  out info varchar(34),
+  out info varchar(35),
   out user_confirmed boolean
 ) returns setof record as $$
 begin
@@ -1529,7 +1529,7 @@ user_pending_deposits (
   out amount numeric(23,8),
   out fee numeric(23,8),
   out created timestamp(3),
-  out info varchar(34)
+  out info varchar(35)
 ) returns setof record as $$
 begin
   if a_uid = 0 then
@@ -1669,7 +1669,7 @@ deposit_withdraw_history (
   out currency varchar(4),
   out fee numeric(23,8),
   out type text,
-  out address varchar(34),
+  out address varchar(35),
   out user_rejected boolean
 ) returns setof record as $$
 begin
@@ -1831,7 +1831,7 @@ create or replace function
 withdraw_crypto (
   a_uid bigint,
   a_amount numeric(23,8),
-  a_address varchar(34),
+  a_address varchar(35),
   a_currency varchar(4),
   a_tfa_code int
 ) returns bigint as $$
@@ -1962,4 +1962,4 @@ drop function if exists trade_fees () cascade;
 drop function if exists dw_limits () cascade;
 drop function if exists get_pairs () cascade;
 drop function if exists chart_from_db (varchar(4), varchar(4)) cascade;
-drop function if exists withdraw_crypto (bigint, numeric(23,8), varchar(34), varchar(4)) cascade;
+drop function if exists withdraw_crypto (bigint, numeric(23,8), varchar(35), varchar(4)) cascade;

--- a/txbits/conf/evolutions/default/2.sql
+++ b/txbits/conf/evolutions/default/2.sql
@@ -781,7 +781,7 @@ get_api_keys (
   a_id bigint,
   out api_key text,
   out comment text,
-  out created timestamp,
+  out created timestamp(3),
   out trading boolean,
   out trade_history boolean,
   out list_balance boolean
@@ -1340,13 +1340,13 @@ $$ language plpgsql volatile security definer set search_path = public, pg_temp 
 create or replace function
 login_log (
   a_uid bigint,
-  a_before timestamp default current_timestamp,
+  a_before timestamp(3) default current_timestamp,
   a_limit integer default 20,
   a_last_id bigint default 0,
   out id bigint,
   out email varchar(256),
   out ip text,
-  out created timestamp,
+  out created timestamp(3),
   out type text
 ) returns setof record as $$
 begin
@@ -1416,7 +1416,7 @@ get_addresses (
   a_uid bigint,
   a_currency varchar(4),
   out o_address varchar(34),
-  out o_assigned timestamp
+  out o_assigned timestamp(3)
 ) returns setof record as $$
 declare
   enabled boolean;;
@@ -1460,7 +1460,7 @@ get_all_addresses (
   a_uid bigint,
   out o_currency varchar(4),
   out o_address varchar(34),
-  out o_assigned timestamp
+  out o_assigned timestamp(3)
 ) returns setof record as $$
 begin
   if a_uid = 0 then
@@ -1505,7 +1505,7 @@ user_pending_withdrawals (
   out currency varchar(4),
   out amount numeric(23,8),
   out fee numeric(23,8),
-  out created timestamp,
+  out created timestamp(3),
   out info varchar(34),
   out user_confirmed boolean
 ) returns setof record as $$
@@ -1528,7 +1528,7 @@ user_pending_deposits (
   out currency varchar(4),
   out amount numeric(23,8),
   out fee numeric(23,8),
-  out created timestamp,
+  out created timestamp(3),
   out info varchar(34)
 ) returns setof record as $$
 begin
@@ -1553,7 +1553,7 @@ user_pending_trades (
   out price numeric(23,8),
   out base varchar(4),
   out counter varchar(4),
-  out created timestamp
+  out created timestamp(3)
 ) returns setof record as $$
 declare
   a_user_id bigint;;
@@ -1584,7 +1584,7 @@ recent_trades (
   a_base varchar(4),
   a_counter varchar(4),
   out amount numeric(23,8),
-  out created timestamp,
+  out created timestamp(3),
   out price numeric(23,8),
   out base varchar(4),
   out counter varchar(4),
@@ -1601,12 +1601,12 @@ create or replace function
 trade_history (
   a_uid bigint,
   a_api_key text,
-  a_before timestamp default current_timestamp,
+  a_before timestamp(3) default current_timestamp,
   a_limit integer default 20,
   a_last_id bigint default 0,
   out id bigint,
   out amount numeric(23,8),
-  out created timestamp,
+  out created timestamp(3),
   out price numeric(23,8),
   out base varchar(4),
   out counter varchar(4),
@@ -1660,12 +1660,12 @@ $$ language plpgsql stable security definer set search_path = public, pg_temp co
 create or replace function
 deposit_withdraw_history (
   a_id bigint,
-  a_before timestamp default current_timestamp,
+  a_before timestamp(3) default current_timestamp,
   a_limit integer default 20,
   a_last_id bigint default 0,
   out id bigint,
   out amount numeric(23,8),
-  out created timestamp,
+  out created timestamp(3),
   out currency varchar(4),
   out fee numeric(23,8),
   out type text,
@@ -1762,9 +1762,9 @@ $$ language sql stable security definer set search_path = public, pg_temp cost 1
 
 create or replace function
 get_recent_matches (
-  a_last_match timestamp,
+  a_last_match timestamp(3),
   out amount numeric(23,8),
-  out created timestamp,
+  out created timestamp(3),
   out price numeric(23,8),
   out base varchar(4),
   out counter varchar(4)
@@ -1814,7 +1814,7 @@ create or replace function
 chart_from_db (
   a_base varchar(4),
   a_counter varchar(4),
-  out start_of_period timestamp,
+  out start_of_period timestamp(3),
   out volume numeric(23,8),
   out low numeric(23,8),
   out high numeric(23,8),
@@ -1873,7 +1873,7 @@ stats_new(
   new_price numeric(23,8)
 ) returns void as $$
 declare
-  period timestamp;;
+  period timestamp(3);;
 begin
   period := date_trunc('hour', current_timestamp) + INTERVAL '30 min' * trunc(extract(minute from current_timestamp) / 30);;
 
@@ -1941,7 +1941,7 @@ drop function if exists delete_expired_tokens () cascade;
 drop function if exists totp_token_is_blacklisted (bigint, bigint) cascade;
 drop function if exists delete_expired_totp_blacklist_tokens () cascade;
 drop function if exists new_log (bigint, text, varchar(256), text, text, inet, text) cascade;
-drop function if exists login_log (bigint, timestamp, integer, bigint) cascade;
+drop function if exists login_log (bigint, timestamp(3), integer, bigint) cascade;
 drop function if exists balance (bigint, text) cascade;
 drop function if exists get_required_confirmations () cascade;
 drop function if exists get_addresses (bigint, varchar(4)) cascade;
@@ -1950,12 +1950,12 @@ drop function if exists user_pending_withdrawals (bigint) cascade;
 drop function if exists user_pending_deposits (bigint) cascade;
 drop function if exists user_pending_trades (bigint, text) cascade;
 drop function if exists recent_trades (varchar(4), varchar(4)) cascade;
-drop function if exists trade_history (bigint, text, timestamp, integer, bigint) cascade;
-drop function if exists deposit_withdraw_history (bigint, timestamp, integer, bigint) cascade;
+drop function if exists trade_history (bigint, text, timestamp(3), integer, bigint) cascade;
+drop function if exists deposit_withdraw_history (bigint, timestamp(3), integer, bigint) cascade;
 drop function if exists open_asks (varchar(4), varchar(4)) cascade;
 drop function if exists open_bids (varchar(4), varchar(4)) cascade;
 drop function if exists orders_depth (varchar(4), varchar(4)) cascade;
-drop function if exists get_recent_matches (timestamp) cascade;
+drop function if exists get_recent_matches (timestamp(3)) cascade;
 drop function if exists get_currencies () cascade;
 drop function if exists dw_fees () cascade;
 drop function if exists trade_fees () cascade;

--- a/txbits/conf/evolutions/default/3.sql
+++ b/txbits/conf/evolutions/default/3.sql
@@ -91,7 +91,7 @@ create or replace function
 create_deposit (
   a_currency varchar(4),
   a_node_id integer,
-  a_address varchar(34),
+  a_address varchar(35),
   a_amount numeric(23,8),
   a_tx_hash varchar(64)
 ) returns bigint as $$
@@ -127,7 +127,7 @@ create or replace function
 create_confirmed_deposit (
   a_currency varchar(4),
   a_node_id integer,
-  a_address varchar(34),
+  a_address varchar(35),
   a_amount numeric(23,8),
   a_tx_hash varchar(64)
 ) returns void as $$
@@ -142,7 +142,7 @@ $$ language plpgsql volatile security invoker set search_path = public, pg_temp 
 
 create or replace function
 is_confirmed_deposit (
-  a_address varchar(34),
+  a_address varchar(35),
   a_amount numeric(23,8),
   a_tx_hash varchar(64)
 ) returns boolean as $$
@@ -157,7 +157,7 @@ get_pending_deposits (
   a_currency varchar(4),
   a_node_id integer,
   out id bigint,
-  out address varchar(34),
+  out address varchar(35),
   out amount numeric(23,8),
   out tx_hash varchar(64)
 ) returns setof record as $$
@@ -172,7 +172,7 @@ $$ language sql stable security invoker set search_path = public, pg_temp cost 1
 create or replace function
 confirmed_deposit (
   a_id bigint,
-  a_address varchar(34),
+  a_address varchar(35),
   a_tx_hash varchar(64),
   a_node_id integer
 ) returns void as $$
@@ -277,7 +277,7 @@ $$ language plpgsql volatile security invoker set search_path = public, pg_temp 
 create or replace function
 get_withdrawal_tx_data (
   a_tx_id bigint,
-  out address varchar(34),
+  out address varchar(35),
   out value numeric(23,8)
 ) returns setof record as $$
   select address, sum(amount - fee) as value
@@ -324,7 +324,7 @@ $$ language plpgsql volatile security invoker set search_path = public, pg_temp 
 create or replace function
 create_cold_storage_transfer (
   a_tx_id bigint,
-  a_address varchar(34),
+  a_address varchar(35),
   a_value numeric(23,8)
 ) returns void as $$
   insert into withdrawals_crypto_tx_cold_storage (id, address, value)
@@ -334,7 +334,7 @@ $$ language sql volatile security invoker set search_path = public, pg_temp cost
 create or replace function
 get_cold_storage_transfer (
   a_tx_id bigint,
-  out address varchar(34),
+  out address varchar(35),
   out value numeric(23,8)
 ) returns record as $$
   select address, value from withdrawals_crypto_tx_cold_storage
@@ -359,18 +359,18 @@ drop function if exists get_node_info (varchar(4), integer) cascade;
 drop function if exists get_balance (varchar(4), integer) cascade;
 drop function if exists get_last_block_read (varchar(4), integer) cascade;
 drop function if exists set_last_block_read (varchar(4), integer, integer, integer) cascade;
-drop function if exists create_deposit (varchar(4), integer, varchar(34), numeric(23,8), varchar(64)) cascade;
-drop function if exists create_confirmed_deposit (varchar(4), integer, varchar(34), numeric(23,8), varchar(64)) cascade;
-drop function if exists is_confirmed_deposit (varchar(34), varchar(64)) cascade;
+drop function if exists create_deposit (varchar(4), integer, varchar(35), numeric(23,8), varchar(64)) cascade;
+drop function if exists create_confirmed_deposit (varchar(4), integer, varchar(35), numeric(23,8), varchar(64)) cascade;
+drop function if exists is_confirmed_deposit (varchar(35), varchar(64)) cascade;
 drop function if exists get_pending_deposits (varchar(4), integer) cascade;
-drop function if exists confirmed_deposit (bigint, varchar(34), varchar(64), integer) cascade;
+drop function if exists confirmed_deposit (bigint, varchar(35), varchar(64), integer) cascade;
 drop function if exists get_unconfirmed_withdrawal_tx (varchar(4), integer) cascade;
 drop function if exists get_last_confirmed_withdrawal_tx (varchar(4), integer) cascade;
 drop function if exists create_withdrawal_tx (varchar(4), integer) cascade;
 drop function if exists get_withdrawal_tx_data (bigint) cascade;
 drop function if exists sent_withdrawal_tx (bigint, varchar(64), numeric(23,8)) cascade;
 drop function if exists confirmed_withdrawal_tx (bigint, numeric(23,8)) cascade;
-drop function if exists create_cold_storage_transfer (bigint, varchar(34), numeric(23,8)) cascade;
+drop function if exists create_cold_storage_transfer (bigint, varchar(35), numeric(23,8)) cascade;
 drop function if exists get_cold_storage_transfer (bigint) cascade;
 drop function if exists set_withdrawal_tx_hash_mutated (bigint, varchar(64)) cascade;
 

--- a/txbits/conf/messages
+++ b/txbits/conf/messages
@@ -97,6 +97,7 @@ exchange.account.api_reference.cancel_order=Cancel Order
 exchange.account.api_reference.list_orders=List Orders
 exchange.account.api_reference.trade_history=Trade History
 exchange.account.api_reference.list_balance=List Balance
+exchange.account.api_reference.type_info=Values with "" are strings. Fields in italics are optional.
 exchange.account.api_reference.example=Example with cURL
 
 exchange.account.api_keys.title=API Keys


### PR DESCRIPTION
The org.joda.time.DateTime class has millisecond precision. We need to have the same precision in the database for comparisons to be valid. Otherwise pagination may not work properly.