### PR TITLE
add a failing test for "bug with incorrect holds calculation during parital matches when bid/ask prices are different"

### DIFF
--- a/txbits/app/models/EngineModel.scala
+++ b/txbits/app/models/EngineModel.scala
@@ -104,6 +104,10 @@ class EngineModel(val db: String = "default") {
     SQL"""update trade_fees set one_way=true""".execute()
   )
 
+  def setTradeFees(linear: BigDecimal) = DB.withConnection(db)(implicit c =>
+    SQL"""update trade_fees set linear = ${linear.bigDecimal}""".execute()
+  )
+
   def setFees(currency: String, method: String, depositConstant: BigDecimal, depositLinear: BigDecimal, withdrawConstant: BigDecimal, withdrawLinear: BigDecimal) = DB.withConnection(db)(implicit c =>
     SQL"""update dw_fees set
          deposit_constant = ${depositConstant.bigDecimal},


### PR DESCRIPTION
This is the test to confirm the fix from #109